### PR TITLE
First release proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ func SomeErrMethod() error {
 }
 
 func SomeMethod() error {
-    // some error returned from another call as err
+    err := SomeErrMethod()
+
     return errors.Wrap(err)
 }
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Indicates that a parameter provided is not in the correct format or not present 
 This error allows to set a property that is related to the error and also add sub validation errors to build a validation error chain.  
 *This error usually translates to a HTTP **422 Unprocessable Entity** error.*
 
+> **Note:** All error constructors return a wrapped version of the error, removing the need to always pair an error constructor with a call to `errors.Wrap`.
+
 ## Error Wrapping
 
 This provides error bubbling tracking and other utility methods to work with wrapped errors.

--- a/application.go
+++ b/application.go
@@ -1,0 +1,18 @@
+package errors
+
+// NewApplicationError returns a ApplicationError instance
+func NewApplicationError(message string) error {
+	return wrap(&ApplicationError{
+		Message: message,
+	}, 4)
+}
+
+// ApplicationError represents a common applicatino error structure
+type ApplicationError struct {
+	Message string
+}
+
+// Error returns the string representation of the error
+func (e *ApplicationError) Error() string {
+	return e.Message
+}

--- a/application_test.go
+++ b/application_test.go
@@ -1,0 +1,21 @@
+package errors
+
+import (
+	"testing"
+)
+
+func TestNewApplicationError(t *testing.T) {
+	err := NewApplicationError("test app error")
+
+	_, ok := GetOriginalError(err).(*ApplicationError)
+	if !ok {
+		t.Errorf("NewApplicationError() returned an incorrect error type %t", err)
+	}
+
+	errMsg := err.Error()
+	expectedErrMsg := "go-errors.TestNewApplicationError ➡︎ test app error"
+
+	if errMsg != expectedErrMsg {
+		t.Errorf("NewApplicationError() returned wrong error message: %s", errMsg)
+	}
+}

--- a/conflict.go
+++ b/conflict.go
@@ -1,0 +1,18 @@
+package errors
+
+// NewConflictError returns a ConflictError instance
+func NewConflictError(message string) error {
+	return wrap(&ConflictError{
+		Message: message,
+	}, 4)
+}
+
+// ConflictError represents an conflict error structure
+type ConflictError struct {
+	Message string
+}
+
+// Error returns the string representation of the error
+func (e *ConflictError) Error() string {
+	return e.Message
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,50 @@
+// Package errors has utilities to create and extend errors, easing the error handling process
+package errors
+
+import (
+	"runtime"
+	"strings"
+)
+
+// Wrap wraps an error with a context message and adds execution path
+func Wrap(err error, messages ...string) error {
+	return wrap(err, 4, messages...)
+}
+
+// Wrap wraps an error with a context message and adds execution path
+func wrap(err error, skipStack int, messages ...string) error {
+	if err != nil {
+		return &wrappedError{
+			originalError: err,
+			path:          getCallerFunction(skipStack),
+			messages:      messages,
+		}
+	}
+
+	return nil
+}
+
+// GetOriginalError returns the original error if the provided error is a WrappedError.
+// Returns the provided error otherwise
+func GetOriginalError(err error) error {
+	wrappedErr, ok := err.(ErrorWrapper)
+	if ok {
+		return wrappedErr.GetOriginalError()
+	}
+
+	return err
+}
+
+// getCallerFunction returns the name of a method in the method chain
+// indicated by the stackOrder index from last to first
+func getCallerFunction(stackOrder int) string {
+	// get caller function path
+	pc := make([]uintptr, 1)
+	runtime.Callers(stackOrder, pc)
+
+	funcRef := runtime.FuncForPC(pc[0])
+
+	funcPath := strings.Split(funcRef.Name(), "/")
+
+	return funcPath[len(funcPath)-1]
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,26 @@
+// Package errors has utilities to create and extend errors, easing the error handling process
+package errors
+
+import (
+	"errors"
+	"testing"
+)
+
+func wrap1() error {
+	return Wrap(errors.New("some error"))
+}
+
+func wrap2() error {
+	return Wrap(wrap1())
+}
+
+func TestWrap(t *testing.T) {
+	err := wrap2()
+
+	errMsg := err.Error()
+	expectedErrMsg := "go-errors.wrap2 ➡︎ go-errors.wrap1 ➡︎ some error"
+
+	if errMsg != expectedErrMsg {
+		t.Errorf("Wrap() returned wrong error message: %s", errMsg)
+	}
+}

--- a/forbidden.go
+++ b/forbidden.go
@@ -1,0 +1,18 @@
+package errors
+
+// NewForbiddenError returns a ForbiddenError instance
+func NewForbiddenError(message string) error {
+	return wrap(&ForbiddenError{
+		Message: message,
+	}, 4)
+}
+
+// ForbiddenError represents an forbidden error structure
+type ForbiddenError struct {
+	Message string
+}
+
+// Error returns the string representation of the error
+func (e *ForbiddenError) Error() string {
+	return e.Message
+}

--- a/notauthorized.go
+++ b/notauthorized.go
@@ -1,0 +1,18 @@
+package errors
+
+// NewNotAuthorizedError returns a NotAuthorizedError instance
+func NewNotAuthorizedError(message string) error {
+	return wrap(&NotAuthorizedError{
+		Message: message,
+	}, 4)
+}
+
+// NotAuthorizedError represents an access restriction error structure
+type NotAuthorizedError struct {
+	Message string
+}
+
+// Error returns the string representation of the error
+func (e *NotAuthorizedError) Error() string {
+	return e.Message
+}

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,47 @@
+package errors
+
+import (
+	"strings"
+)
+
+// NewValidationError returns a ValidationError instance with the provided parameters
+func NewValidationError(field string, message string) error {
+	return wrap(&ValidationError{
+		Field:   field,
+		Message: message,
+	}, 4)
+}
+
+// ValidationError represents an input validation error
+type ValidationError struct {
+	Field   string            `json:"field_name,omitempty"`
+	Message string            `json:"message,omitempty"`
+	Errors  []ValidationError `json:"errors,omitempty"`
+}
+
+func (e *ValidationError) Error() string {
+	var builder = strings.Builder{}
+
+	if e.Field != "" {
+		builder.WriteString(e.Field)
+		builder.WriteString(": ")
+	}
+
+	builder.WriteString(e.Message)
+
+	for _, err := range e.Errors {
+		builder.WriteString("\n - ")
+		builder.WriteString(err.Error())
+		builder.WriteRune(';')
+	}
+
+	return builder.String()
+}
+
+// AddError adds a new validation error to the chain
+func (e *ValidationError) AddError(field string, message string) {
+	e.Errors = append(e.Errors, ValidationError{
+		Field:   field,
+		Message: message,
+	})
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,0 +1,51 @@
+package errors
+
+import (
+	"strings"
+)
+
+// ErrorWrapper defines the interface for an error wrapper that extends an error with additional information
+type ErrorWrapper interface {
+	Error() string
+	GetOriginalError() error
+}
+
+// wrappedError holds an error wrapped with a context message
+type wrappedError struct {
+	originalError error
+	path          string
+	messages      []string
+}
+
+// Error returns the string representation of the error
+func (err *wrappedError) Error() string {
+	builder := strings.Builder{}
+
+	builder.WriteString(err.path)
+
+	if len(err.messages) > 0 {
+		builder.WriteString(": ")
+
+		for _, message := range err.messages {
+			builder.WriteString(message)
+			builder.WriteString("; ")
+		}
+	}
+
+	builder.WriteString(" ➡︎ ")
+	builder.WriteString(err.originalError.Error())
+
+	return builder.String()
+}
+
+// GetOriginalError returns the original error
+func (err *wrappedError) GetOriginalError() error {
+	if err.originalError != nil {
+		originalError, ok := (err.originalError).(ErrorWrapper)
+		if ok {
+			return originalError.GetOriginalError()
+		}
+	}
+
+	return err.originalError
+}


### PR DESCRIPTION
Implements all main features cited in README:

- Custom error types
- ErrorWrapper interface
- Package level utility methods

An improvement over the internal version is that the error constructors return a wrapped error, removing the need to chain `Wrap` calls with error constructors.